### PR TITLE
Kubernetes operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,77 @@
 <details>
+<summary><b>Выполнено ДЗ №8</b></summary>
+
+ - [X] Основное ДЗ
+ - [X] Задания со *
+
+## В процессе сделано:
+ - Задание по CRD: выставленны все поля как обязательные
+ - MySQL контроллер: Поправлены темплейты, а также добавлено удаление PV котое не удалялось хотя и есть в зависимостях. Самописный
+   Вопрос: почему объект создался, хотя мы создали CR, до того, как запустили контроллер?
+   Согласно документации https://kopf.readthedocs.io/en/latest/walkthrough/starting/ это нрмальное поведение, и скорее всего при запуске оператора kopf смотрит events.events.k8s.io и от туда выберает нужные события.
+ - Деплой оператора: из образа docker.io/vii98/mysql-operator:latest
+ - Проверки ручные прошли
+ - Задание со звездой 1: В конце функции ставится:
+   ```python
+      return {'message': f"mysql-instance created {r_result} restore-job"}
+   ```
+   который и отображается в статусе
+   `r_result` берется в зависимости от успешности выполнения:
+   ```python
+   api.create_namespaced_job('default', restore_job)
+   ```
+ - Задание со звездой 2: выполнено
+   Работает:
+   ```bash
+   [vii@localhost deploy]$ export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
+   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+   mysql: [Warning] Using a password on the command line interface can be insecure.
+   +----+-------------+
+   | id | name        |
+   +----+-------------+
+   |  1 | some data   |
+   |  2 | some data-2 |
+   +----+-------------+
+   [vii@localhost deploy]$ kubectl patch mysqls.otus.homework mysql-instance --patch "$(echo -e 'spec:\n  password: otuspassword1')" --type=merge
+   mysql.otus.homework/mysql-instance patched
+   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+   mysql: [Warning] Using a password on the command line interface can be insecure.
+   ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
+   command terminated with exit code 1
+   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword1 -e "select * from test;" otus-database
+   mysql: [Warning] Using a password on the command line interface can be insecure.
+   +----+-------------+
+   | id | name        |
+   +----+-------------+
+   |  1 | some data   |
+   |  2 | some data-2 |
+   +----+-------------+
+   ```python
+@kopf.on.update('mysqls', field='spec.password') #Подписываемся на события из mysqls с изменением в поле spec.password
+def update_pass(spec, name, old, new, status, namespace, logger, **kwargs):
+    api_instance = kubernetes.client.api.core_v1_api.CoreV1Api()
+    result = api_instance.list_namespaced_pod(namespace, label_selector="app="+name, watch=False) #Ищем нужный под
+    exec_command = [
+            '/bin/sh',
+            '-c',
+            f"mysql -u root -p{ old } -e \"update user set authentication_string=password(\'{new}\') where user='root';FLUSH PRIVILEGES;\" mysql"] #Формируем команду которая сменит пароль
+    if len(result.items) == 1: #На всякий случай проверяем что под нашелся и он один
+        if result.items[0].status.phase == 'Running': #На всякий случай проверяем что он в статусе Running
+            resp = kubernetes.stream.stream(api_instance.connect_get_namespaced_pod_exec,  result.items[0].metadata.name,  namespace,  command=exec_command,  stderr=True, stdin=True, stdout=True, tty=False) #Меняем пароль
+            print(f"{resp}") #Для дебага :)
+   ```
+   
+   
+## Вопросы:
+ - Вопрос: почему объект создался, хотя мы создали CR, до того, как запустили контроллер?
+   Когда контроллер запустился он прочитал "БД" и сравнил с тем с соянием на текущий момент.
+
+## PR checklist:
+ - [X] Выставлен label с темой домашнего задания
+</details>
+
+
+<details>
 <summary><b>Выполнено ДЗ №7</b></summary>
 
  - [X] Основное ДЗ

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@
    ```python
    api.create_namespaced_job('default', restore_job)
    ```
+   результат:
+```bash
+[vii@localhost deploy]$ kubectl describe mysqls.otus.homework mysql-instance | grep ^Status -A2
+Status:
+  mysql_on_create:
+    Message:  mysql-instance created with restore-job
+```
  - Задание со звездой 2: выполнено
    Работает:
    ```bash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@
    |  1 | some data   |
    |  2 | some data-2 |
    +----+-------------+
-   ```python
+   ```
+```python
 @kopf.on.update('mysqls', field='spec.password') #Подписываемся на события из mysqls с изменением в поле spec.password
 def update_pass(spec, name, old, new, status, namespace, logger, **kwargs):
     api_instance = kubernetes.client.api.core_v1_api.CoreV1Api()
@@ -59,12 +60,7 @@ def update_pass(spec, name, old, new, status, namespace, logger, **kwargs):
         if result.items[0].status.phase == 'Running': #На всякий случай проверяем что он в статусе Running
             resp = kubernetes.stream.stream(api_instance.connect_get_namespaced_pod_exec,  result.items[0].metadata.name,  namespace,  command=exec_command,  stderr=True, stdin=True, stdout=True, tty=False) #Меняем пароль
             print(f"{resp}") #Для дебага :)
-   ```
-   
-   
-## Вопросы:
- - Вопрос: почему объект создался, хотя мы создали CR, до того, как запустили контроллер?
-   Когда контроллер запустился он прочитал "БД" и сравнил с тем с соянием на текущий момент.
+```
 
 ## PR checklist:
  - [X] Выставлен label с темой домашнего задания

--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,149 @@
+import kopf
+import yaml
+import kubernetes
+import time
+import logging
+from jinja2 import Environment, FileSystemLoader
+
+from kubernetes.stream import stream
+from kubernetes.client.api import core_v1_api
+
+logger = logging.getLogger(__name__)
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                logger.info(f"job with { jobname }  found,wait untill end")
+                if job.status.succeeded == 1:
+                    logger.info(f"job with { jobname }  success")
+                    job_finished = True
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.load(yaml_manifest, Loader=yaml.FullLoader)
+    return json_manifest
+
+def delete_success_jobs(mysql_instance_name):
+    logger.info("start deletion")
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if (jobname == f"backup-{mysql_instance_name}-job") or (jobname == f"restore-{mysql_instance_name}-job"):
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname, 'default', propagation_policy='Background')
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+# Функция, которая будет запускаться при создании объектов тип MySQL:
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image'] # cохраняем в переменные содержимое описания MySQL из CR
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+    
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+    logger.info(f"{ persistent_volume_claim }")
+    service = render_template('mysql-service.yml.j2', {'name': name})
+    deployment = render_template('mysql-deployment.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    restore_job = render_template('restore-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+
+    # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body) # addopt
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    kopf.append_owner_reference(restore_job, owner=body)
+    # ^ Таким образом при удалении CR удалятся все, связанные с ним pv,pvc,svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+    # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        r_result = 'with'
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        r_result = 'without'
+        pass
+
+    # Cоздаем PVC  и PV для бэкапов:
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name, 'storage_size': storage_size})
+        api = kubernetes.client.CoreV1Api()
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        logger.info(f"error create persistent volume \"backup-{ name }-pv\"")
+        pass
+
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name, 'storage_size': storage_size})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        logger.info(f"error create persistent volume claim \"backup-{ name }-pvc\"")
+        pass
+    return {'message': f"mysql-instance created {r_result} restore-job"}
+
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    delete_success_jobs(name)
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    api.delete_namespaced_job('default', name)
+    apiv1 = kubernetes.client.CoreV1Api()
+    apiv1.delete_persistent_volume(f"{ name }-pv")
+    return {'message': "mysql and its children resources deleted"}
+
+
+@kopf.on.update('mysqls', field='spec.password')
+def update_pass(spec, name, old, new, status, namespace, logger, **kwargs):
+    api_instance = kubernetes.client.api.core_v1_api.CoreV1Api()
+    result = api_instance.list_namespaced_pod(namespace, label_selector="app="+name, watch=False)
+    exec_command = [
+            '/bin/sh',
+            '-c',
+            f"mysql -u root -p{ old } -e \"update user set authentication_string=password(\'{new}\') where user='root';FLUSH PRIVILEGES;\" mysql"]
+    if len(result.items) == 1:
+        if result.items[0].status.phase == 'Running':
+            resp = kubernetes.stream.stream(api_instance.connect_get_namespaced_pod_exec,  result.items[0].metadata.name,  namespace,  command=exec_command,  stderr=True, stdin=True, stdout=True, tty=False)
+            print(f"{resp}")

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/pv-backup/
+

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        args:
+        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Delete
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: mysql:5.7
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }}< /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms
+  validation:
+    openAPIV3Schema:
+      type: object
+      required:
+        - apiVersion
+        - kind
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+          required:
+          - name
+          properties:
+            name:
+              type: string
+        spec:
+          type: object
+          required:
+            - image
+            - database
+            - password
+            - storage_size
+          properties:
+            image: 
+              type: string
+            database:
+              type: string
+            password:
+              type: string
+            storage_size:
+              type: string

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "docker.io/vii98/mysql-operator:latest"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
Выполнено ДЗ №8

 - [X] Основное ДЗ
 - [X] Задания со *

## В процессе сделано:
 - Задание по CRD: выставленны все поля как обязательные
 - MySQL контроллер: Поправлены темплейты, а также добавлено удаление PV котое не удалялось хотя и есть в зависимостях. Самописный
   Вопрос: почему объект создался, хотя мы создали CR, до того, как запустили контроллер?
   Согласно документации https://kopf.readthedocs.io/en/latest/walkthrough/starting/ это нрмальное поведение, и скорее всего при запуске оператора kopf смотрит events.events.k8s.io и от туда выберает нужные события.
 - Деплой оператора: из образа docker.io/vii98/mysql-operator:latest
 - Проверки ручные прошли
 - Задание со звездой 1: В конце функции ставится:
   ```python
      return {'message': f"mysql-instance created {r_result} restore-job"}
   ```
   который и отображается в статусе
   `r_result` берется в зависимости от успешности выполнения:
   ```python
   api.create_namespaced_job('default', restore_job)
   ```
   результат:
```bash
[vii@localhost deploy]$ kubectl describe mysqls.otus.homework mysql-instance | grep ^Status -A2
Status:
  mysql_on_create:
    Message:  mysql-instance created with restore-job
```
 - Задание со звездой 2: выполнено
   Работает:
   ```bash
   [vii@localhost deploy]$ export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
   mysql: [Warning] Using a password on the command line interface can be insecure.
   +----+-------------+
   | id | name        |
   +----+-------------+
   |  1 | some data   |
   |  2 | some data-2 |
   +----+-------------+
   [vii@localhost deploy]$ kubectl patch mysqls.otus.homework mysql-instance --patch "$(echo -e 'spec:\n  password: otuspassword1')" --type=merge
   mysql.otus.homework/mysql-instance patched
   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
   mysql: [Warning] Using a password on the command line interface can be insecure.
   ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
   command terminated with exit code 1
   [vii@localhost deploy]$ kubectl exec -it $MYSQLPOD -- mysql -potuspassword1 -e "select * from test;" otus-database
   mysql: [Warning] Using a password on the command line interface can be insecure.
   +----+-------------+
   | id | name        |
   +----+-------------+
   |  1 | some data   |
   |  2 | some data-2 |
   +----+-------------+
   ```
```python
@kopf.on.update('mysqls', field='spec.password') #Подписываемся на события из mysqls с изменением в поле spec.password
def update_pass(spec, name, old, new, status, namespace, logger, **kwargs):
    api_instance = kubernetes.client.api.core_v1_api.CoreV1Api()
    result = api_instance.list_namespaced_pod(namespace, label_selector="app="+name, watch=False) #Ищем нужный под
    exec_command = [
            '/bin/sh',
            '-c',
            f"mysql -u root -p{ old } -e \"update user set authentication_string=password(\'{new}\') where user='root';FLUSH PRIVILEGES;\" mysql"] #Формируем команду которая сменит пароль
    if len(result.items) == 1: #На всякий случай проверяем что под нашелся и он один
        if result.items[0].status.phase == 'Running': #На всякий случай проверяем что он в статусе Running
            resp = kubernetes.stream.stream(api_instance.connect_get_namespaced_pod_exec,  result.items[0].metadata.name,  namespace,  command=exec_command,  stderr=True, stdin=True, stdout=True, tty=False) #Меняем пароль
            print(f"{resp}") #Для дебага :)
```

## PR checklist:
 - [X] Выставлен label с темой домашнего задания